### PR TITLE
Add more info to sdk.to_managed_object's description for easier searching

### DIFF
--- a/src/api/sdk.md
+++ b/src/api/sdk.md
@@ -181,7 +181,7 @@ Attempts to convert `value` to an [REManagedObject*](types/REManagedObject.md).
 `value` can be any of the following types:
 
 * An [REManagedObject*](types/REManagedObject.md), in which case it is returned as-is
-* A lua number convertible to `uintptr_t`
+* A lua number convertible to `uintptr_t`, representing the object's address
 * A `void*`
 
 Any other type will return `nil`.


### PR DESCRIPTION
I'm quite new to all this, so while I went straight to sdk.md to search for a method to convert an address(string/number) into a pointer, I couldn't find this method, and had the same results when searching for "address" in github.io's search bar. I think this will make the method easier to find if someone else tries to in the future.